### PR TITLE
Adds ASM Group ID with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ header.SetFilter("footer", filter)
 
 ```
 
+### [ASM Group ID](https://sendgrid.com/docs/User_Guide/advanced_suppression_manager.html)
+
+```go
+asmGroupID := 1
+header.SetASMGroupID(asmGroupID)
+```
+
 ### JSONString
 
 ```go

--- a/smtpapi.go
+++ b/smtpapi.go
@@ -1,9 +1,9 @@
 package smtpapi
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"bytes"
 )
 
 // SMTPAPIHeader will be used to set up X-SMTPAPI params
@@ -14,6 +14,7 @@ type SMTPAPIHeader struct {
 	Category   []string            `json:"category,omitempty"`
 	UniqueArgs map[string]string   `json:"unique_args,omitempty"`
 	Filters    map[string]Filter   `json:"filters,omitempty"`
+	ASMGroupID int                 `json:"asm_group_id,omitempty"`
 }
 
 // Filter represents an App/Filter and its settings
@@ -93,6 +94,11 @@ func (h *SMTPAPIHeader) SetCategories(categories []string) {
 	h.Category = categories
 }
 
+// SetASMGroupID will set the value of the ASMGroupID field
+func (h *SMTPAPIHeader) SetASMGroupID(groupID int) {
+	h.ASMGroupID = groupID
+}
+
 // AddUniqueArg will set the value of a specific argument
 func (h *SMTPAPIHeader) AddUniqueArg(arg, value string) {
 	if h.UniqueArgs == nil {
@@ -150,5 +156,3 @@ func (h *SMTPAPIHeader) JSONString() (string, error) {
 	headers, e := json.Marshal(h)
 	return escapeUnicode(string(headers)), e
 }
-
-

--- a/smtpapi_test.go
+++ b/smtpapi_test.go
@@ -182,6 +182,15 @@ func TestSetFilter(t *testing.T) {
 	}
 }
 
+func TestSetASMGroupID(t *testing.T) {
+	header := NewSMTPAPIHeader()
+	header.SetASMGroupID(1)
+	result, _ := header.JSONString()
+	if result != ExampleJson()["set_asm_group_id"] {
+		t.Errorf("Result did not match")
+	}
+}
+
 func TestJSONString(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	result, _ := header.JSONString()
@@ -212,7 +221,7 @@ func TestJSONStringWithAdds(t *testing.T) {
 }
 
 func TestJSONStringWithSets(t *testing.T) {
-	validHeader, _ := json.Marshal([]byte(`{"to":["test@email.com"],"sub":{"subKey":["subValue"]},"section":{"testSection":"sectionValue"},"category":["testCategory"],"unique_args":{"testUnique":"uniqueValue"},"filters":{"testFilter":{"settings":{"filter":"filterValue"}}}}`))
+	validHeader, _ := json.Marshal([]byte(`{"to":["test@email.com"],"sub":{"subKey":["subValue"]},"section":{"testSection":"sectionValue"},"category":["testCategory"],"unique_args":{"testUnique":"uniqueValue"},"filters":{"testFilter":{"settings":{"filter":"filterValue"}}},"asm_group_id":1}`))
 	header := NewSMTPAPIHeader()
 	header.SetTos([]string{"test@email.com"})
 	sub := make(map[string][]string)
@@ -226,6 +235,7 @@ func TestJSONStringWithSets(t *testing.T) {
 	unique["testUnique"] = "uniqueValue"
 	header.SetUniqueArgs(unique)
 	header.AddFilter("testFilter", "filter", "filterValue")
+	header.SetASMGroupID(1)
 	if h, e := header.JSONString(); e != nil {
 		t.Errorf("Error! %s", e)
 	} else {

--- a/smtpapi_test_strings.json
+++ b/smtpapi_test_strings.json
@@ -12,5 +12,6 @@
   "add_section": "{\"section\":{\"set_section_key\":\"set_section_value\",\"set_section_key_2\":\"set_section_value_2\"}}",
   "set_sections": "{\"section\":{\"set_section_key\":\"set_section_value\"}}",
   "add_filter": "{\"filters\":{\"footer\":{\"settings\":{\"text/html\":\"<strong>boo</strong>\"}}}}",
-  "set_filters": "{\"filters\":{\"footer\":{\"settings\":{\"enable\":\"1\",\"text/plain\":\"You can haz footers!\"}}}}"
+  "set_filters": "{\"filters\":{\"footer\":{\"settings\":{\"enable\":\"1\",\"text/plain\":\"You can haz footers!\"}}}}",
+  "set_asm_group_id": "{\"asm_group_id\":1}"
 }


### PR DESCRIPTION
Adds support for the ASM Group ID which is a new top level setting added to the XSMTP-API header.
Includes tests.
