### PR TITLE
Fix small value Unicode JSON parse error

### DIFF
--- a/smtpapi.go
+++ b/smtpapi.go
@@ -139,7 +139,7 @@ func escapeUnicode(input string) string {
 	buffer := bytes.NewBufferString("")
 	for _, r := range input {
 		if r > 127 {
-			var s = fmt.Sprintf("\\u%x", r)
+			var s = fmt.Sprintf("\\u04%x", r)
 			//fmt.Printf("%s", s)
 			buffer.WriteString(s)
 		} else {

--- a/smtpapi_test.go
+++ b/smtpapi_test.go
@@ -2,7 +2,6 @@ package smtpapi
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"reflect"
 	"testing"
@@ -120,7 +119,6 @@ func TestAddCategoryUnicode(t *testing.T) {
 	if result != ExampleJson()["add_category_unicode"] {
 		t.Errorf("Result did not match")
 	}
-	fmt.Println(result)
 }
 
 func TestAddCategories(t *testing.T) {


### PR DESCRIPTION
this fixes this error we've getting back from the Sendgrid SMTP api:
code:400 error:<nil> body:{"message": "error", "errors": ["JSON in x-smtpapi could not be parsed"]}
...
our response contains mangled Unicode characters:
{"body":"\u003cp\u003eYouâ€™re a winner!"}
...
adding the 4 character pad allows fmt.Sprintf to format the encoding correctly
