### PR TITLE
add loader

### DIFF
--- a/smtpapi.go
+++ b/smtpapi.go
@@ -185,3 +185,8 @@ func (h *SMTPAPIHeader) JSONString() (string, error) {
 	headers, e := json.Marshal(h)
 	return escapeUnicode(string(headers)), e
 }
+
+// Load allows you to load a pre-formed x-smtpapi header
+func (h *SMTPAPIHeader) Load(b []byte) error {
+	return json.Unmarshal(b, h)
+}


### PR DESCRIPTION
Helper method that I needed and thought it would be worth sharing. If you store your x-smtpapi header in a file and want to load it in, this is how you would do that.