### PR TITLE
Add support for non-string filter settings

### DIFF
--- a/smtpapi.go
+++ b/smtpapi.go
@@ -26,7 +26,7 @@ type SMTPAPIHeader struct {
 
 // Filter represents an App/Filter and its settings
 type Filter struct {
-	Settings map[string]string `json:"settings,omitempty"`
+	Settings map[string]interface{} `json:"settings,omitempty"`
 }
 
 // NewSMTPAPIHeader creates a new header struct
@@ -120,13 +120,13 @@ func (h *SMTPAPIHeader) SetUniqueArgs(args map[string]string) {
 }
 
 // AddFilter will set the specific setting for a filter
-func (h *SMTPAPIHeader) AddFilter(filter, setting, value string) {
+func (h *SMTPAPIHeader) AddFilter(filter, setting string, value interface{}) {
 	if h.Filters == nil {
 		h.Filters = make(map[string]Filter)
 	}
 	if _, ok := h.Filters[filter]; !ok {
 		h.Filters[filter] = Filter{
-			Settings: make(map[string]string),
+			Settings: make(map[string]interface{}),
 		}
 	}
 	h.Filters[filter].Settings[setting] = value

--- a/smtpapi_test.go
+++ b/smtpapi_test.go
@@ -178,9 +178,9 @@ func TestAddFilter(t *testing.T) {
 func TestSetFilter(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	filter := &Filter{
-		Settings: make(map[string]string),
+		Settings: make(map[string]interface{}),
 	}
-	filter.Settings["enable"] = "1"
+	filter.Settings["enable"] = 1
 	filter.Settings["text/plain"] = "You can haz footers!"
 	header.SetFilter("footer", filter)
 	result, _ := header.JSONString()

--- a/smtpapi_test_strings.json
+++ b/smtpapi_test_strings.json
@@ -12,7 +12,7 @@
   "add_section": "{\"section\":{\"set_section_key\":\"set_section_value\",\"set_section_key_2\":\"set_section_value_2\"}}",
   "set_sections": "{\"section\":{\"set_section_key\":\"set_section_value\"}}",
   "add_filter": "{\"filters\":{\"footer\":{\"settings\":{\"text/html\":\"<strong>boo</strong>\"}}}}",
-  "set_filters": "{\"filters\":{\"footer\":{\"settings\":{\"enable\":\"1\",\"text/plain\":\"You can haz footers!\"}}}}",
+  "set_filters": "{\"filters\":{\"footer\":{\"settings\":{\"enable\":1,\"text/plain\":\"You can haz footers!\"}}}}",
   "set_send_at": "{\"send_at\":1428611024}",
   "add_send_each_at": "{\"send_each_at\":[1428611024,1428611025]}",
   "set_send_each_at": "{\"send_each_at\":[1428611024,1428611025]}",


### PR DESCRIPTION
Changes the type of `Filter.Settings` to map[string]interface{} to support non-string filters, like the "enable" flag which should be represented with an integer `1` or `0` as specified in the API reference example:

``` json
{
  "filters": {
    "footer": {
      "settings":
        {
          "enable": 1,
          "text/plain": "Thank you for your business"
        }
    }
  }
}
```

(pulled from https://sendgrid.com/docs/API_Reference/SMTP_API/index.html#-The-XSMTPAPI-Header)

closes sendgrid/smtpapi-go#12
