### PR TITLE
Revised Github repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All updates to this library is documented in our [CHANGELOG](https://github.com/
 ## Install Package
 
 ```bash
-go get github.com/sendgrid/smtpapi/go
+go get github.com/sendgrid/smtpapi-go
 ```
 
 # Quick Start


### PR DESCRIPTION
This PR fixes the repository URL for the bash command. I had copied and pasted the current command and received an error: 

```
go get github.com/sendgrid/smtpapi/go
# cd .; git clone https://github.com/sendgrid/smtpapi /Users/aimeelaplant/gocode/src/github.com/sendgrid/smtpapi
Cloning into '/Users/aimeelaplant/gocode/src/github.com/sendgrid/smtpapi'...
remote: Repository not found.
fatal: repository 'https://github.com/sendgrid/smtpapi/' not found
package github.com/sendgrid/smtpapi/go: exit status 128
```