### PR TITLE
Smallfixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
 - tip
+script: go test -cover -bench=. -v -race ./...
 notifications:
   hipchat:
     rooms:

--- a/smtpapi_test.go
+++ b/smtpapi_test.go
@@ -293,3 +293,31 @@ func TestJSONStringWithSets(t *testing.T) {
 		}
 	}
 }
+
+func TestMarshalUnmarshall(t *testing.T) {
+	header := NewSMTPAPIHeader()
+	header.SetTos([]string{"test@email.com"})
+	sub := make(map[string][]string)
+	sub["subKey"] = []string{"subValue"}
+	header.SetSubstitutions(sub)
+	sections := make(map[string]string)
+	sections["testSection"] = "sectionValue"
+	header.SetSections(sections)
+	header.SetCategories([]string{"testCategory"})
+	unique := make(map[string]string)
+	unique["testUnique"] = "uniqueValue"
+	header.SetUniqueArgs(unique)
+	header.AddFilter("testFilter", "filter", "filterValue")
+	header.SetASMGroupID(1)
+	header.SetIpPool("testPool")
+
+	newHeader := NewSMTPAPIHeader()
+	b, err := header.JSONString()
+	if err != nil {
+		t.Errorf("Error in JSONString %v", err)
+	}
+	newHeader.Load([]byte(b))
+	if !reflect.DeepEqual(header, newHeader) {
+		t.Errorf("Expected %v, but got %v", header, newHeader)
+	}
+}

--- a/smtpapi_test.go
+++ b/smtpapi_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func ExampleJson() map[string]interface{} {
+func exampleJson() map[string]interface{} {
 	data, _ := ioutil.ReadFile("smtpapi_test_strings.json")
 	var f interface{}
 	json.Unmarshal(data, &f)
@@ -32,7 +32,7 @@ func TestAddTo(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	header.AddTo("addTo@mailinator.com")
 	result, _ := header.JSONString()
-	if result != ExampleJson()["add_to"] {
+	if result != exampleJson()["add_to"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -42,7 +42,7 @@ func TestAddTos(t *testing.T) {
 	tos := []string{"addTo@mailinator.com"}
 	header.AddTos(tos)
 	result, _ := header.JSONString()
-	if result != ExampleJson()["add_to"] {
+	if result != exampleJson()["add_to"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -51,7 +51,7 @@ func TestSetTos(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	header.SetTos([]string{"setTos@mailinator.com"})
 	result, _ := header.JSONString()
-	if result != ExampleJson()["set_tos"] {
+	if result != exampleJson()["set_tos"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -60,7 +60,7 @@ func TestAddSubstitution(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	header.AddSubstitution("sub", "val")
 	result, _ := header.JSONString()
-	if result != ExampleJson()["add_substitution"] {
+	if result != exampleJson()["add_substitution"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -69,7 +69,7 @@ func TestAddSubstitutions(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	header.AddSubstitutions("sub", []string{"val"})
 	result, _ := header.JSONString()
-	if result != ExampleJson()["add_substitution"] {
+	if result != exampleJson()["add_substitution"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -80,7 +80,7 @@ func TestSetSubstitutions(t *testing.T) {
 	sub["sub"] = []string{"val"}
 	header.SetSubstitutions(sub)
 	result, _ := header.JSONString()
-	if result != ExampleJson()["set_substitutions"] {
+	if result != exampleJson()["set_substitutions"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -90,7 +90,7 @@ func TestAddSection(t *testing.T) {
 	header.AddSection("set_section_key", "set_section_value")
 	header.AddSection("set_section_key_2", "set_section_value_2")
 	result, _ := header.JSONString()
-	if result != ExampleJson()["add_section"] {
+	if result != exampleJson()["add_section"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -101,7 +101,7 @@ func TestSetSections(t *testing.T) {
 	sections["set_section_key"] = "set_section_value"
 	header.SetSections(sections)
 	result, _ := header.JSONString()
-	if result != ExampleJson()["set_sections"] {
+	if result != exampleJson()["set_sections"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -111,7 +111,7 @@ func TestAddCategory(t *testing.T) {
 	header.AddCategory("addCategory")
 	header.AddCategory("addCategory2")
 	result, _ := header.JSONString()
-	if result != ExampleJson()["add_category"] {
+	if result != exampleJson()["add_category"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -122,7 +122,7 @@ func TestAddCategoryUnicode(t *testing.T) {
 	header.AddCategory("カテゴリ2Unicode")
 	header.AddCategory("鼖")
 	result, _ := header.JSONString()
-	if result != ExampleJson()["add_category_unicode"] {
+	if result != exampleJson()["add_category_unicode"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -132,7 +132,7 @@ func TestAddCategories(t *testing.T) {
 	categories := []string{"addCategory", "addCategory2"}
 	header.AddCategories(categories)
 	result, _ := header.JSONString()
-	if result != ExampleJson()["add_category"] {
+	if result != exampleJson()["add_category"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -141,7 +141,7 @@ func TestSetCategories(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	header.SetCategories([]string{"setCategories"})
 	result, _ := header.JSONString()
-	if result != ExampleJson()["set_categories"] {
+	if result != exampleJson()["set_categories"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -151,7 +151,7 @@ func TestAddUniqueArg(t *testing.T) {
 	header.AddUniqueArg("add_unique_argument_key", "add_unique_argument_value")
 	header.AddUniqueArg("add_unique_argument_key_2", "add_unique_argument_value_2")
 	result, _ := header.JSONString()
-	if result != ExampleJson()["add_unique_arg"] {
+	if result != exampleJson()["add_unique_arg"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -162,7 +162,7 @@ func TestSetUniqueArgs(t *testing.T) {
 	args["set_unique_argument_key"] = "set_unique_argument_value"
 	header.SetUniqueArgs(args)
 	result, _ := header.JSONString()
-	if result != ExampleJson()["set_unique_args"] {
+	if result != exampleJson()["set_unique_args"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -184,7 +184,7 @@ func TestSetFilter(t *testing.T) {
 	filter.Settings["text/plain"] = "You can haz footers!"
 	header.SetFilter("footer", filter)
 	result, _ := header.JSONString()
-	if result != ExampleJson()["set_filters"] {
+	if result != exampleJson()["set_filters"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -193,7 +193,7 @@ func TestSetSendAt(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	header.SetSendAt(1428611024)
 	result, _ := header.JSONString()
-	if result != ExampleJson()["set_send_at"] {
+	if result != exampleJson()["set_send_at"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -203,7 +203,7 @@ func TestAddSendEachAt(t *testing.T) {
 	header.AddSendEachAt(1428611024)
 	header.AddSendEachAt(1428611025)
 	result, _ := header.JSONString()
-	if result != ExampleJson()["add_send_each_at"] {
+	if result != exampleJson()["add_send_each_at"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -213,7 +213,7 @@ func TestSetSendEachAt(t *testing.T) {
 	sendEachAt := []int64{1428611024, 1428611025}
 	header.SetSendEachAt(sendEachAt)
 	result, _ := header.JSONString()
-	if result != ExampleJson()["set_send_each_at"] {
+	if result != exampleJson()["set_send_each_at"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -222,7 +222,7 @@ func TestSetASMGroupID(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	header.SetASMGroupID(1)
 	result, _ := header.JSONString()
-	if result != ExampleJson()["set_asm_group_id"] {
+	if result != exampleJson()["set_asm_group_id"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -231,7 +231,7 @@ func TestSetIpPool(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	header.SetIpPool("testPool")
 	result, _ := header.JSONString()
-	if result != ExampleJson()["set_ip_pool"] {
+	if result != exampleJson()["set_ip_pool"] {
 		t.Errorf("Result did not match")
 	}
 }
@@ -239,7 +239,7 @@ func TestSetIpPool(t *testing.T) {
 func TestJSONString(t *testing.T) {
 	header := NewSMTPAPIHeader()
 	result, _ := header.JSONString()
-	if result != ExampleJson()["json_string"] {
+	if result != exampleJson()["json_string"] {
 		t.Errorf("Result did not match")
 	}
 }


### PR DESCRIPTION
Made 3 commits:
First, Go Vet noticed this:
```
smtpapi-go [master u=]: go vet ./...
smtpapi_test.go:10: ExampleJson should return nothing
smtpapi_test.go:10: ExampleJson refers to unknown identifier: Json
exit status 1
```
Second, get to 100% code coverage, by verifying the Marshal and Unmarshal work by exercising the Load method.

Third, update .travis.yml to display code coverage and enable the race detector.